### PR TITLE
Escape XML for methodName anche className

### DIFF
--- a/src/main/java/airbrake/Backtrace.java
+++ b/src/main/java/airbrake/Backtrace.java
@@ -4,11 +4,12 @@
 
 package airbrake;
 
-import static airbrake.ValidBacktraces.*;
-
-import java.text.*;
-import java.util.*;
-import java.util.regex.*;
+import java.text.MessageFormat;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.regex.Pattern;
 
 public class Backtrace implements Iterable<String> {
 

--- a/src/main/java/airbrake/BacktraceLine.java
+++ b/src/main/java/airbrake/BacktraceLine.java
@@ -4,7 +4,7 @@
 
 package airbrake;
 
-import static java.text.MessageFormat.*;
+import static java.text.MessageFormat.format;
 
 public class BacktraceLine {
 
@@ -79,6 +79,11 @@ public class BacktraceLine {
 	}
 
 	public String toXml() {
-		return format("<line method=\"{0}.{1}\" file=\"{2}\" number=\"{3}\"/>", className, methodName, fileName, lineNumber);
+		return format("<line method=\"{0}.{1}\" file=\"{2}\" number=\"{3}\"/>", 
+		  NoticeXml.escapeXml(className),
+		  NoticeXml.escapeXml(methodName),
+		  fileName,
+		  lineNumber
+		);
 	}
 }


### PR DESCRIPTION
Hi,

I've found an error while sending stacktrace in the XML.
in particular my application uses ORMLite and the stacktrace contains:
```xml
<line method="org.sqlite.PrepStmt.<init>" file="PrepStmt.java" number="42"/>
```
The `<init>` method name makes XML syntax invalid.
So I have added `NoticeXml.escapeXml` to `methodName` and, just for sure, to `className`.

Hope this can help

Fabio