### PR TITLE
Airbrakenotifier notify method uses synchronic Http calls

### DIFF
--- a/src/main/java/airbrake/AirbrakeNotifier.java
+++ b/src/main/java/airbrake/AirbrakeNotifier.java
@@ -6,69 +6,80 @@ package airbrake;
 
 import java.io.*;
 import java.net.*;
+import java.util.concurrent.Executors;
 
 public class AirbrakeNotifier {
 
-	public static String slurp(InputStream stream) {
-		try {
-			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			byte[] buff = new byte[4096];
-			for (int len; (len = stream.read(buff)) != -1;) {
-				outputStream.write(buff, 0, len);
-			}
-			return outputStream.toString();
+    public static String slurp(InputStream stream) {
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            byte[] buff = new byte[4096];
+            for (int len; (len = stream.read(buff)) != -1; ) {
+                outputStream.write(buff, 0, len);
+            }
+            return outputStream.toString();
 
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	private String url;
+    private String url;
 
-	public AirbrakeNotifier() {
-		setUrl("http://api.airbrake.io/notifier_api/v2/notices");
-	}
+    public AirbrakeNotifier() {
+        setUrl("http://api.airbrake.io/notifier_api/v2/notices");
+    }
 
-	public AirbrakeNotifier(String url) {
-		setUrl(url);
-	}
+    public AirbrakeNotifier(String url) {
+        setUrl(url);
+    }
 
-	private void addingPropertiesTo(final HttpURLConnection connection) throws ProtocolException {
-		connection.setDoOutput(true);
-		connection.setRequestProperty("Content-type", "text/xml");
-		connection.setRequestProperty("Accept", "text/xml, application/xml");
-		connection.setRequestMethod("POST");
-	}
+    private void addingPropertiesTo(final HttpURLConnection connection) throws ProtocolException {
+        connection.setDoOutput(true);
+        connection.setRequestProperty("Content-type", "text/xml");
+        connection.setRequestProperty("Accept", "text/xml, application/xml");
+        connection.setRequestMethod("POST");
+    }
 
-	private HttpURLConnection createConnection() throws IOException {
-		return (HttpURLConnection) new URL(url).openConnection();
-	}
+    private HttpURLConnection createConnection() throws IOException {
+        return (HttpURLConnection) new URL(url).openConnection();
+    }
 
-	public int notify(final AirbrakeNotice notice) {
-		try {
-			final HttpURLConnection airbrakeConnection = createConnection();
-			addingPropertiesTo(airbrakeConnection);
-			String noticeXml = new NoticeXml(notice).toString();
-			return send(noticeXml, airbrakeConnection);
-		} catch (final Exception e) {
-			printStacktrace(notice, e);
-		}
-		return 0;
-	}
+    public int notifySync(final AirbrakeNotice notice) {
+        try {
+            final HttpURLConnection airbrakeConnection = createConnection();
+            addingPropertiesTo(airbrakeConnection);
+            String noticeXml = new NoticeXml(notice).toString();
+            return send(noticeXml, airbrakeConnection);
+        } catch (final Exception e) {
+            printStacktrace(notice, e);
+        }
+        return 0;
+    }
 
-	private void printStacktrace(final AirbrakeNotice notice, final Exception e) {
-		e.printStackTrace();
-	}
+    public void notifyAsync(final AirbrakeNotice notice) {
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                notifySync(notice);
+            }
+        };
+        Executors.newSingleThreadExecutor().submit(runnable);
+    }
 
-	private int send(final String xml, final HttpURLConnection connection) throws IOException {
-		final OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream());
-		writer.write(xml);
-		writer.close();
-		int statusCode = connection.getResponseCode();
-		return statusCode;
-	}
+    private void printStacktrace(final AirbrakeNotice notice, final Exception e) {
+        e.printStackTrace();
+    }
 
-	public void setUrl(String url) {
-		this.url = url;
-	}
+    private int send(final String xml, final HttpURLConnection connection) throws IOException {
+        final OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream());
+        writer.write(xml);
+        writer.close();
+        int statusCode = connection.getResponseCode();
+        return statusCode;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
 }

--- a/src/main/java/airbrake/AirbrakeNotifier.java
+++ b/src/main/java/airbrake/AirbrakeNotifier.java
@@ -10,76 +10,77 @@ import java.util.concurrent.Executors;
 
 public class AirbrakeNotifier {
 
-    public static String slurp(InputStream stream) {
-        try {
-            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-            byte[] buff = new byte[4096];
-            for (int len; (len = stream.read(buff)) != -1; ) {
-                outputStream.write(buff, 0, len);
+      public static String slurp(InputStream stream) {
+            try {
+                  ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+                  byte[] buff = new byte[4096];
+                  for (int len; (len = stream.read(buff)) != -1; ) {
+                        outputStream.write(buff, 0, len);
+                  }
+                  return outputStream.toString();
+
+            } catch (Exception e) {
+                  throw new RuntimeException(e);
             }
-            return outputStream.toString();
+      }
 
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
+      private String url;
 
-    private String url;
+      public AirbrakeNotifier() {
+            setUrl("http://api.airbrake.io/notifier_api/v2/notices");
+      }
 
-    public AirbrakeNotifier() {
-        setUrl("http://api.airbrake.io/notifier_api/v2/notices");
-    }
+      public AirbrakeNotifier(String url) {
+            setUrl(url);
+      }
 
-    public AirbrakeNotifier(String url) {
-        setUrl(url);
-    }
+      private void addingPropertiesTo(final HttpURLConnection connection) throws ProtocolException {
+            connection.setDoOutput(true);
+            connection.setRequestProperty("Content-type", "text/xml");
+            connection.setRequestProperty("Accept", "text/xml, application/xml");
+            connection.setRequestMethod("POST");
+      }
 
-    private void addingPropertiesTo(final HttpURLConnection connection) throws ProtocolException {
-        connection.setDoOutput(true);
-        connection.setRequestProperty("Content-type", "text/xml");
-        connection.setRequestProperty("Accept", "text/xml, application/xml");
-        connection.setRequestMethod("POST");
-    }
+      private HttpURLConnection createConnection() throws IOException {
+            return (HttpURLConnection) new URL(url).openConnection();
+      }
 
-    private HttpURLConnection createConnection() throws IOException {
-        return (HttpURLConnection) new URL(url).openConnection();
-    }
-
-    public int notifySync(final AirbrakeNotice notice) {
-        try {
-            final HttpURLConnection airbrakeConnection = createConnection();
-            addingPropertiesTo(airbrakeConnection);
-            String noticeXml = new NoticeXml(notice).toString();
-            return send(noticeXml, airbrakeConnection);
-        } catch (final Exception e) {
-            printStacktrace(notice, e);
-        }
-        return 0;
-    }
-
-    public void notifyAsync(final AirbrakeNotice notice) {
-        Runnable runnable = new Runnable() {
-            @Override
-            public void run() {
-                notifySync(notice);
+      public int notify(final AirbrakeNotice notice) {
+            try {
+                  final HttpURLConnection airbrakeConnection = createConnection();
+                  addingPropertiesTo(airbrakeConnection);
+                  String noticeXml = new NoticeXml(notice).toString();
+                  return send(noticeXml, airbrakeConnection);
+            } catch (final Exception e) {
+                  printStacktrace(notice, e);
             }
-        };
-        Executors.newSingleThreadExecutor().submit(runnable);
-    }
+            return 0;
+      }
 
-    private void printStacktrace(final AirbrakeNotice notice, final Exception e) {
-        e.printStackTrace();
-    }
+      public void notifyAsync(final AirbrakeNotice notice) {
+            final AirbrakeNotifier airbrakeNotifier = this;
+            Runnable runnable = new Runnable() {
+                  @Override
+                  public void run() {
+                        airbrakeNotifier.notify(notice);
+                  }
+            };
+            Executors.newSingleThreadExecutor().submit(runnable);
+      }
 
-    private int send(final String xml, final HttpURLConnection connection) throws IOException {
-        final OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream());
-        writer.write(xml);
-        writer.close();
-        int statusCode = connection.getResponseCode();
-        return statusCode;
-    }
+      private void printStacktrace(final AirbrakeNotice notice, final Exception e) {
+            e.printStackTrace();
+      }
 
-    public void setUrl(String url) {
-        this.url = url;
-    }
+      private int send(final String xml, final HttpURLConnection connection) throws IOException {
+            final OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream());
+            writer.write(xml);
+            writer.close();
+            int statusCode = connection.getResponseCode();
+            return statusCode;
+      }
+
+      public void setUrl(String url) {
+            this.url = url;
+      }
 }


### PR DESCRIPTION
#44 I've changed the name of the notify method as notifySync and added a new method named notifyAsync. Now exception mappers/handlers do not need to wait for airbrake http connection.

Sorry for the indentation.

Changes line =  47-58 NotifySync method / 60-68 NotifyAsync method
