### PR TITLE
Fix XML escaping for quotes

### DIFF
--- a/src/main/java/airbrake/NoticeXml.java
+++ b/src/main/java/airbrake/NoticeXml.java
@@ -167,7 +167,7 @@ public class NoticeXml {
 			boolean controlCharacter = ch < 32;
 			boolean unicodeButNotAscii = ch > 126;
 			boolean characterWithSpecialMeaningInXML = ch == '<' || ch == '&'
-					|| ch == '>';
+					|| ch == '>' || ch == '"' || ch == '\'';
 			if (characterWithSpecialMeaningInXML || unicodeButNotAscii
 					|| controlCharacter) {
 				stringBuffer.append("&#" + (int) ch + ";");


### PR DESCRIPTION
Fixes the XML for backtraces that include quotes in them. 

*Maintainer*: Please release this on Maven central if at all possible, otherwise add the jar to the github hosted mvn repo please.

## Before:

```xml
<line method="Caused by For input string "789jklasBDFHLJKASHFD".Caused by For input string "789jklasBDFHLJKASHFD""
                  file="Caused by For input string "789jklasBDFHLJKASHFD".Caused by For input string "789jklasBDFHLJKASHFD"" number="-1"/>
```

## After:
```xml
 <line method="Caused by For input string &#34;789jklasBDFHLJKASHFD&#34;.Caused by For input string &#34;789jklasBDFHLJKASHFD&#34;"
                  file="Caused by For input string &#34;789jklasBDFHLJKASHFD&#34;" number="-1"/>
```
